### PR TITLE
Changed text in email cancellation

### DIFF
--- a/parkstay/templates/ps/email/cancel.txt
+++ b/parkstay/templates/ps/email/cancel.txt
@@ -3,7 +3,7 @@
 {% block content %}
 Your booking REF {{booking.confirmation_number}}, arrival {{booking.arrival|date:"d/m/Y"}} at {{booking.campground.name}}, {{booking.campground.park.name}} has been cancelled.
 
-If we received an email from you notifying us of cancellation more than 28 days before your booking arrival date, 50% of the total fees paid will be refunded to the account used to make payment within 30 days.
+Any refund will be completed as soon as possible and will be confirmed by separate email.
 
 View my Park Stay WA bookings {{my_bookings}}
 {% endblock %}


### PR DESCRIPTION
changed text from 
'If we received an email from you notifying us of cancellation more than 28 days before your booking arrival date, 50% of the total fees paid will be refunded to the account used to make payment within 30 days.' 
to 
'Any refund will be completed as soon as possible and will be confirmed by separate email' .